### PR TITLE
Route requests from radio buttons to any page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -19,7 +19,7 @@ router.use(function (req, res, next) {
  res.locals.formQuery = res.locals.formQuery.slice(0,-1);
 
  next();
- 
+
 });
 
 router.get('/', function (req, res) {
@@ -50,6 +50,11 @@ router.get('/create_account/enter_details', function (req, res) {
 
   }
 
+});
+
+// Check if we've got to this page but user actually selected harvest
+router.get('/menu', function (req, res) {
+  res.redirect(req.query.goto);
 });
 
 module.exports = router;

--- a/app/views/manage_data/index.html
+++ b/app/views/manage_data/index.html
@@ -25,7 +25,7 @@
 
     <div class="column-two-thirds">
 
-      <form method="get" action="/manage_data/upload_new_dataset/title_summary" class="form">
+      <form method="get" action="/menu" class="form">
 
       {{formData | safe}}
 
@@ -40,22 +40,22 @@
 
           <div class="form-group">
             <label for="create-dataset" class="block-label">
-              <input type="radio" id="create-dataset" name="create-dataset" value="yes">
+              <input type="radio" id="create-dataset" name="goto" value="/manage_data/upload_new_dataset/title_summary">
               Upload a new dataset
             </label>
 
             <label for="update-dataset" class="block-label">
-              <input type="radio" id="update-dataset" name="update-dataset" value="no">
+              <input type="radio" id="update-dataset" name="goto" value="/">
               Update or add to a existing dataset
             </label>
 
             <label for="pull-data" class="block-label">
-              <input type="radio" id="pull-data" name="pull-data" value="no">
+              <input type="radio" id="pull-data" name="goto" value="/harvest/new">
               Pull data: we’ll harvest your data
             </label>
 
             <label for="push-data-to-api" class="block-label">
-              <input type="radio" id="push-data-to-api" name="push-data-to-api" value="no">
+              <input type="radio" id="push-data-to-api" name="goto" value="/pull">
               Push data to API integration
             </label>
 


### PR DESCRIPTION
Rather than try to handle routes by intercepting urls on the
backend, this allows us to call /menu with a query param (it's a GET)
called goto, and then redirect to that page.

For instance

``` html
    <form action="/menu" method="get">
       <radio name="goto" value="/somewhere/togo">
       <radio name="goto" value="/somewhere/else">
    </form>
```
