### PR TITLE
Adds some templates for the suggested harvesting workflow

### DIFF
--- a/app/views/harvest/ckan.html
+++ b/app/views/harvest/ckan.html
@@ -1,0 +1,75 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+{% include "includes/phase_banner_beta.html" %}
+
+  <div class="grid-row">
+
+    {% include "includes/side-navigation.html" %}
+
+    <div class="column-two-thirds">
+
+ <form method="get" action="/menu" class="form">
+
+
+        <h1 class="heading-large">
+          Please choose which organisations to harvest
+        </h1>
+
+        <p>We have identified your catalogue as a CKAN catalogue</p>
+
+        <p>There are 3 organisations in your catalogue</p>
+
+        <p>Please choose which of these organisations you wish to harvest from</p>
+
+        <fieldset>
+          <legend class="visuallyhidden">
+            Choose catalogue
+          </legend>
+
+          <div class="form-group">
+            <label for="create-dataset" class="block-label">
+              <input type="checkbox" id="ckan" name="goto" value="/harvest/frequency">
+              All 3 organisations
+            </label>
+            <label for="create-dataset" class="block-label">
+              <input type="checkbox" id="ckan" name="goto" value="/harvest/frequency">
+              Finance Department
+            </label>
+            <label for="create-dataset" class="block-label">
+              <input type="checkbox" id="ckan" name="goto" value="/harvest/frequency">
+              Environmental Department
+            </label>
+            <label for="create-dataset" class="block-label">
+              <input type="checkbox" id="ckan" name="goto" value="/harvest/frequency">
+              Roads Department
+            </label>
+          </div>
+
+        </fieldset>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue" />
+        </div>
+
+      </form>
+    </div>
+  </div>
+
+</main>
+{% endblock %}

--- a/app/views/harvest/done.html
+++ b/app/views/harvest/done.html
@@ -1,0 +1,71 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+{% include "includes/phase_banner_beta.html" %}
+
+  <div class="grid-row">
+
+    {% include "includes/side-navigation.html" %}
+
+    <div class="column-two-thirds">
+
+      <form method="get" action="/dashboard" class="form">
+
+      {{formData | safe}}
+
+        <h1 class="heading-large">
+          Your harvester has been created
+        </h1>
+
+        <p>The harvester has been created and a first-run has been scheduled to run in the next 30 minutes.</p>
+
+        <h2 class="heading-medium">
+          Would you like to be notified of changes after each harvest?
+        </h2>
+
+        <fieldset>
+          <legend class="visuallyhidden">
+            Would you like to be notified?
+          </legend>
+
+          <div class="form-group">
+            <label for="notify-1" class="block-label">
+              <input type="radio" id="notify-1" name="" value="yes">
+              Yes
+            </label>
+
+            <label for="notify-2" class="block-label">
+              <input type="radio" id="notify-2" name="" value="no">
+              No
+            </label>
+
+          </div>
+
+        </fieldset>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue" />
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+
+</main>
+{% endblock %}

--- a/app/views/harvest/frequency.html
+++ b/app/views/harvest/frequency.html
@@ -1,0 +1,77 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+{% include "includes/phase_banner_beta.html" %}
+
+  <div class="grid-row">
+
+    {% include "includes/side-navigation.html" %}
+
+    <div class="column-two-thirds">
+
+ <form method="get" action="/menu" class="form">
+
+      {{formData | safe}}
+
+        <h1 class="heading-large">
+          Please choose a harvest frequency
+        </h1>
+
+        <p>Please select how frequently you would like us to extract data </p>
+
+        <fieldset>
+          <legend class="visuallyhidden">
+            Choose catalogue
+          </legend>
+
+          <div class="form-group">
+            <label for="create-dataset" class="block-label">
+              <input type="radio" id="ckan" name="goto" value="/harvest/done">
+              Every day
+            </label>
+            <label for="create-dataset" class="block-label">
+              <input type="radio" id="ckan" name="goto" value="/harvest/done">
+              Every week
+            </label>
+            <label for="create-dataset" class="block-label">
+              <input type="radio" id="ckan" name="goto" value="/harvest/done">
+              Every month
+            </label>
+            <label for="create-dataset" class="block-label">
+              <input type="radio" id="ckan" name="goto" value="/harvest/done">
+              Every 3 months
+            </label>
+
+            <label for="create-dataset" class="block-label">
+              <input type="radio" id="ckan" name="goto" value="/harvest/done">
+              I'll run it manually
+            </label>
+          </div>
+
+        </fieldset>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue" />
+        </div>
+
+      </form>
+    </div>
+  </div>
+
+</main>
+{% endblock %}

--- a/app/views/harvest/new.html
+++ b/app/views/harvest/new.html
@@ -1,0 +1,76 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+{% include "includes/phase_banner_beta.html" %}
+
+  <div class="grid-row">
+
+    {% include "includes/side-navigation.html" %}
+
+    <div class="column-two-thirds">
+
+      <form method="get" action="/harvest/ckan" class="form">
+
+      {{formData | safe}}
+
+        <h1 class="heading-large">
+          Create a new harvester
+        </h1>
+
+        <p>You must provide a name and the URL of the catalogue from where we can harvest datasets</p>
+
+
+        <br>
+
+        <fieldset>
+          <legend class="visuallyhidden">
+          Create a harvester
+          </legend>
+
+          <div class="form-group">
+            <label class="form-label" for="title-dataset">Name</label>
+            <span class="form-hint">
+                Give this harvester a name so that you can identify it<br/>
+                at a later time.
+            </span>
+            <input class="form-control form-control-2-3" id="" name="" type="text">
+          </div>
+
+
+          <div class="form-group">
+            <label class="form-label" for="title-dataset">URL</label>
+            <span class="form-hint">
+              Provide the URL from where your data catalogue can<br/>
+              be found, including the http:// or https://
+            </span>
+            <input class="form-control form-control-2-3" id="" name="" type="text">
+          </div>
+
+        </fieldset>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue" />
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+
+</main>
+{% endblock %}

--- a/app/views/harvest/unknown.html
+++ b/app/views/harvest/unknown.html
@@ -1,0 +1,93 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+{% include "includes/phase_banner_beta.html" %}
+
+  <div class="grid-row">
+
+    {% include "includes/side-navigation.html" %}
+
+    <div class="column-two-thirds">
+
+ <form method="get" action="/menu" class="form">
+
+      {{formData | safe}}
+
+        <h1 class="heading-large">
+          Please choose your data catalogue
+        </h1>
+
+        <p>We were unable to determine the type of data catalogue you are using</p>
+
+        <p>Please provide more information below, or contact <a>Support</a> for help</p>
+
+        <fieldset>
+          <legend class="visuallyhidden">
+            Choose catalogue
+          </legend>
+
+          <div class="form-group">
+            <label for="create-dataset" class="block-label">
+              <input type="radio" id="ckan" name="goto" value="/harvest/ckan">
+              CKAN
+            </label>
+
+            <label for="update-dataset" class="block-label">
+              <input type="radio" id="socrata" name="goto" value="/harvest/ckan">
+              Publish My Data
+            </label>
+
+            <label for="update-dataset" class="block-label">
+              <input type="radio" id="socrata" name="goto" value="/harvest/ckan">
+              LGA Inventory
+            </label>
+
+            <label for="update-dataset" class="block-label">
+              <input type="radio" id="socrata" name="goto" value="/harvest/ckan">
+              Socrata
+            </label>
+
+            <label for="update-dataset" class="block-label">
+              <input type="radio" id="socrata" name="goto" value="/harvest/ckan">
+              INSPIRE - WMS
+            </label>
+
+            <label for="update-dataset" class="block-label">
+              <input type="radio" id="socrata" name="goto" value="/harvest/ckan">
+              INSPIRE - CSW
+            </label>
+
+            <label for="update-dataset" class="block-label">
+              <input type="radio" id="socrata" name="goto" value="/harvest/ckan">
+              INSPIRE - A web accessible folder
+            </label>
+
+          </div>
+
+        </fieldset>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue" />
+        </div>
+
+      </form>
+    </div>
+  </div>
+
+</main>
+{% endblock %}


### PR DESCRIPTION
Adds some templates to work through the suggested harvester workflow.

Step 1 is adding a title and a URL, which then submits to a page telling
the user we have identified the catalogue and showing a list of
organisations from which they can harvest - note there is also a page at
/harvest/unknown which asks the user to specify which catalogue they
use.

The user is then asked how frequently they wish to have the harvester
run, then whether they want notifications after each run.

And that's it.
