### PR TITLE
Adds an overview/detail view of the harvesters

### DIFF
--- a/app/views/harvest/list.html
+++ b/app/views/harvest/list.html
@@ -1,0 +1,73 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+{% include "includes/phase_banner_beta.html" %}
+
+  <div class="grid-row">
+
+    {% include "includes/side-navigation.html" %}
+
+    <div class="column-two-thirds">
+
+        <h1 class="heading-large">
+          Harvesters
+        </h1>
+
+        <p>These are the harvesters that are configured for Land Registry that will perform a bulk import on a regular schedule</p>
+
+        <table>
+          <thead>
+            <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Last activity</th>
+                <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/harvest/view">Default</a></td>
+              <td>CKAN</td>
+              <td>Today</td>
+              <td>
+              Ok
+              </td>
+            </tr>
+            <tr>
+              <td><a href="/harvest/view_failed">Inspire Geo Data</a></td>
+              <td>INSPIRE - WMS</td>
+              <td>Monday</td>
+              <td>
+                <div class="error" style="color: #B10E1E;">
+                Failed
+                </div>
+              </td>
+            </tr>
+
+          </tbody>
+        </table>
+
+        <p>
+          <a href="/harvest/new" class="button">Add new harvester</a>
+        </p>
+      </div>
+    </div>
+  </div>
+
+</main>
+{% endblock %}

--- a/app/views/harvest/view.html
+++ b/app/views/harvest/view.html
@@ -1,0 +1,107 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+{% include "includes/phase_banner_beta.html" %}
+
+  <div class="grid-row">
+
+    {% include "includes/side-navigation.html" %}
+
+    <div class="column-two-thirds">
+
+      <form method="get" action="/harvest/ckan" class="form">
+
+      {{formData | safe}}
+
+        <h1 class="heading-large">
+          Default harvester
+        </h1>
+
+
+        <table>
+          <thead>
+            <tr>
+              <th colspan="2">Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Type</td>
+              <td>CKAN</td>
+            </tr>
+            <tr>
+              <td>URL</td>
+              <td>...</td>
+            </tr>
+            <tr>
+              <td>Organisations</td>
+              <td>All</td>
+            </tr>
+            <tr>
+              <td>Last run</td>
+              <td>Yesterday</td>
+            </tr>
+            <tr>
+              <td>Datasets processed</td>
+              <td>4</td>
+            </tr>
+            <tr>
+             <td>Warnings</td>
+              <td>0</td>
+            </tr>
+          </tbody>
+        </table>
+
+
+
+        <h2 class="heading-medium">
+        Imported datasets
+        </h2>
+        <p>The following datasets were imported on the last run</p>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Status</td>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><a href="">Administrative Areas</a></td>
+                    <td>New</td>
+                </tr>
+                <tr>
+                    <td><a href="">Spending data</a></td>
+                    <td>Updated</td>
+                </tr>
+                <tr>
+                    <td><a href="">Price Paid Data</a></td>
+                    <td>Updated</td>
+                </tr>
+                <tr>
+                    <td><a href="">UK House Price Index</a></td>
+                    <td>Updated</td>
+                </tr>
+            </tbody>
+        </table>
+
+    </div>
+  </div>
+
+</main>
+{% endblock %}

--- a/app/views/harvest/view_failed.html
+++ b/app/views/harvest/view_failed.html
@@ -1,0 +1,89 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+{% include "includes/phase_banner_beta.html" %}
+
+  <div class="grid-row">
+
+    {% include "includes/side-navigation.html" %}
+
+    <div class="column-two-thirds">
+
+      <form method="get" action="/harvest/ckan" class="form">
+
+      {{formData | safe}}
+
+        <h1 class="heading-large">
+          Inspire Geo Data
+        </h1>
+
+        <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-2" tabindex="-1">
+
+          <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
+            The harvester failed to run
+          </h1>
+
+          <p>
+            There was no response from the server when we tried to contact it.<br/>
+            Please check that the URL is correct and the server is running.
+          </p>
+        </div>
+
+
+        <table>
+          <thead>
+            <tr>
+              <th colspan="2">Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Type</td>
+              <td>INSPIRE - WMS</td>
+            </tr>
+            <tr>
+              <td>URL</td>
+              <td>...</td>
+            </tr>
+            <tr>
+              <td>Last run</td>
+              <td>Yesterday</td>
+            </tr>
+            <tr>
+              <td>Datasets processed</td>
+              <td>0</td>
+            </tr>
+            <tr>
+             <td>Warnings</td>
+              <td>1</td>
+            </tr>
+          </tbody>
+        </table>
+
+
+
+        <h2 class="heading-medium">
+        Imported datasets
+        </h2>
+        <p>No datasets were imported on the last run</p>
+
+    </div>
+  </div>
+
+</main>
+{% endblock %}


### PR DESCRIPTION
So that users can see how their harvesters are behaving or when they
click on a notification that a harvester failed I've added:
- A page that lists top level details about the harvesters that are
  currently configured
- A detail page that shows info on the last run, and what was imported.
  There is also a view showing what is displayed when a harvester fails
  (they do).

This should fix #5 
