### PR TITLE
Change team management to include permissions on invite page.

### DIFF
--- a/app/views/team/index.html
+++ b/app/views/team/index.html
@@ -25,51 +25,63 @@
     <div class="column-two-thirds">
 
         <h1 class="heading-large">
-          Land Registry Users
+          Team members
         </h1>
 
-        <p>Here you can manage the users who are able to publish data<br/>
-        for Land Registry</p>
+        <div class="form-group">
+          <a class="button" href="/team/invite">Invite team member</a>
+        </div>
 
-        <table>
-          <thead>
-            <tr>
-                <th>User</th>
-                <th>Last activity</th>
-                <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Louise Petre</td>
-              <td>Today</td>
-              <td>
-                <a href="/settings/users">Edit</a>
-                <a href="/settings/users">Remove</a>
-              </td>
-            </tr>
-            <tr>
-              <td>Maria Izquierdo</td>
-              <td>This week</td>
-              <td>
-                <a href="/settings/users">Edit</a>
-                <a href="/settings/users">Remove</a>
-              </td>
-            </tr>
-            <tr>
-              <td>Tom Hughes</td>
-              <td>Today</td>
-              <td>
-                <a href="/settings/users">Edit</a>
-                <a href="/settings/users">Remove</a>
-              </td>
-            </tr>
-          </tbody>
-        </table>
 
-        <p>
-        <a class="button" href="/team/invite">Add a new user</a>
-        </p>
+        <div class="grid-row bordered"></div>
+
+        <!-- Foreach user -->
+        <div class="grid-row bordered font-xsmall">
+          <div class="column-full team-member-name">
+            Louise Petre
+          </div>
+          <div class="column-one-quarter font-xsmall">
+            <img src="/public/images/tick.svg"/>
+            Create datasets
+          </div>
+          <div class="column-one-quarter font-xsmall">
+            <img src="/public/images/tick.svg"/>
+            Publish datasets
+          </div>
+          <div class="column-one-quarter font-xsmall">
+            <img src="/public/images/tick.svg"/>
+            Manage Harvest
+          </div>
+          <div class="column-one-quarter font-xsmall">
+            <img src="/public/images/tick.svg"/>
+            Manage Team
+          </div>
+        </div>
+        <!-- end foreach user -->
+
+        <div class="grid-row bordered font-xsmall">
+          <div class="column-full team-member-name">
+            Maria Izquierdo
+          </div>
+          <div class="column-one-quarter font-xsmall">
+            <img src="/public/images/tick.svg"/>
+            Create datasets
+          </div>
+          <div class="column-one-quarter font-xsmall">
+            <img src="/public/images/tick.svg"/>
+            Publish datasets
+          </div>
+          <div class="column-one-quarter font-xsmall">
+            <img src="/public/images/tick.svg"/>
+            Manage Harvest
+          </div>
+          <div class="column-one-quarter font-xsmall">
+            <img src="/public/images/tick.svg"/>
+            Manage Team
+          </div>
+        </div>
+
+
       </div>
     </div>
   </div>

--- a/app/views/team/invite.html
+++ b/app/views/team/invite.html
@@ -24,17 +24,11 @@
 
     <div class="column-two-thirds">
 
-      <form method="get" action="/settings/user_permissions" class="form">
+      <form method="get" action="/team" class="form">
 
         <h1 class="heading-large">
-          Invite a new user
+          Invite a team membmer
         </h1>
-
-        <p>You can invite another person to help you manage the<br/>
-        Land Registry datasets by providing their email address</p>
-
-        <p>If the user is already registered they will be added to the<br/>
-        Organisation immediately</p>
 
         <fieldset>
           <legend class="visuallyhidden">
@@ -43,7 +37,7 @@
 
 
           <div class="form-group">
-            <label class="form-label" for="summary-dataset">Email address</label>
+            <label class="form-label bold" for="summary-dataset">Email address</label>
             <span class="form-hint">
               The email address of the person to invite
             </span>
@@ -52,8 +46,46 @@
 
         </fieldset>
 
+
+        <fieldset>
+          <legend class="visuallyhidden">
+            Please choose the permissions for the new user.
+          </legend>
+
+          <p class="bold">Permissions</p>
+
+          <div class="form-group">
+            <label for="create" class="block-label">
+              <input type="checkbox" id="create" name="create" value="">
+              Create and Edit datasets
+            </label>
+            <label for="publish" class="block-label">
+              <input type="checkbox" id="publish" name="publish" value="">
+              Publish datasets
+            </label>
+            <label for="harvesters" class="block-label">
+              <input type="checkbox" id="harvesters" name="harvesters" value="">
+              Manage harvesters
+            </label>
+            <label for="admin" class="block-label">
+              <input type="checkbox" id="admin" name="admin" value="">
+              Manage the Land Registry Organisation
+            </label>
+          </div>
+
+        </fieldset>
+
+        <p>
+          All team members can see
+          <ul class="list list-bullet">
+              <li>Datasets that are not published</li>
+              <li>Team notifications and tasks to be done</li>
+          </ul>
+        </p>
+
+
         <div class="form-group">
-          <a class="button" class="button" href="/team/user_permissions">Continue</a>
+          <a class="button" class="button" href="/team">Send invitation email</a>
         </div>
 
       </form>

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1,3 +1,14 @@
+.bordered {
+  border-bottom: solid 2px #ddd;
+  padding-top: 1em;
+  padding-bottom: 1em;
+}
+
+.team-member-name {
+  padding-left: 1em;
+  padding-bottom: 1em;
+}
+
 .grid-row:after, #content:after, .notice:after, .panel:after, fieldset:after, .form-group:after, .form-block:after, .breadcrumbs ol:after {
   content: "";
   display: block;


### PR DESCRIPTION
Moves the permissions onto the same page as we ask for the email address.

Changes the display of current team members, still need to clarify how we edit permissions on existing users and remove them from the team.

Fixes #48
