### PR TITLE
Simple CSV preview

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -26,6 +26,24 @@ pre.language-markup {
   background-color: #F5F2F0;
 }
 
+.csv-preview {
+  border:5px solid #dee0e2;
+  margin:30px 0 30px
+}
+.csv-preview-inner {
+  border:1px solid #bfc1c3;
+  padding:10px 24px;
+  height: 800px;
+  overflow:auto
+}
+
+.error-cell {
+  background-color: #FF5353;
+  color: #fff;
+  padding: 4px;
+  font-weight: bold;
+}
+
 #back a {
   display: inline-block;
   margin-top: 15px;

--- a/app/views/datasets/preview/csv.html
+++ b/app/views/datasets/preview/csv.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+  <main id="content" role="main">
+
+    {% include "includes/phase_banner_alpha.html" %}
+
+    <div class="grid-row">
+
+
+      {% include "includes/side-navigation.html" %}
+
+
+      <div class="column-two-thirds" style="width:80%;">
+
+        <h1 class="heading-large">Preview CSV data</h1>
+
+
+        {% include "includes/csv_good.html" %}
+
+      </div>
+  </main>
+{% endblock %}

--- a/app/views/datasets/preview/csv_error.html
+++ b/app/views/datasets/preview/csv_error.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Publish government data
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "includes/propositional_navigation_service.html" %}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block content %}
+
+  <main id="content" role="main">
+
+    {% include "includes/phase_banner_alpha.html" %}
+
+    <div class="grid-row">
+
+
+      {% include "includes/side-navigation.html" %}
+
+
+      <div class="column-two-thirds" style="width:80%;">
+
+        <h1 class="heading-large">Preview CSV errors</h1>
+
+
+        {% include "includes/csv_bad.html" %}
+
+      </div>
+  </main>
+{% endblock %}

--- a/app/views/includes/csv_bad.html
+++ b/app/views/includes/csv_bad.html
@@ -1,0 +1,1232 @@
+<div class="csv-preview">
+  <div class="csv-preview-inner">
+    <table>
+      <thead>
+         <tr>
+              <th>Department Family</th>
+              <th>Entity</th>
+              <th>Date</th>
+              <th>Expense Type</th>
+              <th>Expense Area</th>
+              <th>Supplier</th>
+              <th>SME</th>
+              <th>Transaction Number</th>
+              <th>Amount</th>
+              <th>Description</th>
+              <th>Expenditure Type</th>
+          </tr>
+      </thead>
+      <tbody>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td class="error-cell">15 Sept</td>
+            <td>Data Network Lines</td>
+            <td>IS Service Delivery</td>
+            <td>British Telecommunications Plc</td>
+            <td>Large</td>
+            <td>1159166</td>
+            <td>35721.33</td>
+            <td>Data Network Lines</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td class="error-cell">19 Sept</td>
+            <td>Electricity</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>420066</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>875.93</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>7,097.04</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>192.40</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>3,696.98</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>3,701.29</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>30,432.22</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,535.87</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>5,894.01</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>2,865.12</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>6,092.37</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,270.62</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,048.04</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,417.59</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>5,436.75</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>-21.76</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>8,064.40</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>17,748.31</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>6,418.59</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>4,055.30</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>7,906.03</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>3,612.09</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>6,540.85</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>9,400.98</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>6,184.36</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Peterborough Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>3,524.37</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>RFS4 - Coventry</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.76</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>6,305.12</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>5,336.08</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>2,670.47</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>4,471.53</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,978.43</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>422.65</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>8,871.67</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>11,419.56</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,774.31</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>9,930.33</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>9,945.71</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>5,034.24</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>213.98</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>4,788.25</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Peterborough Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>2,050.89</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>754.56</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>4,320.54</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>12,157.95</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>65.64</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>43.76</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Peterborough Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.89</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>43.76</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>90.59</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,350.48</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>43.50</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>200.00</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>5,476.74</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>2,550.60</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>362.16</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>545.99</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>2,006.53</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>200.00</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>9.86</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,566.28</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>220.85</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>3,291.32</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>512.40</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,047.92</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>2,530.55</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>744.72</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,815.15</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>276.06</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>429.86</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>-7.21</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>517.42</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>1,370.55</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>539.50</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>375.19</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>501.27</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>540.35</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>421.63</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>471.95</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>1,667.13</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Peterborough Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>550.64</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>RFS4 - Coventry</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>7.21</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/includes/csv_good.html
+++ b/app/views/includes/csv_good.html
@@ -1,0 +1,1219 @@
+<div class="csv-preview">
+  <div class="csv-preview-inner">
+    <table>
+      <thead>
+         <tr>
+              <th>Department Family</th>
+              <th>Entity</th>
+              <th>Date</th>
+              <th>Expense Type</th>
+              <th>Expense Area</th>
+              <th>Supplier</th>
+              <th>SME</th>
+              <th>Transaction Number</th>
+              <th>Amount</th>
+              <th>Description</th>
+              <th>Expenditure Type</th>
+          </tr>
+      </thead>
+      <tbody>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>15/09/2016</td>
+            <td>Data Network Lines</td>
+            <td>IS Service Delivery</td>
+            <td>British Telecommunications Plc</td>
+            <td>Large</td>
+            <td>1159166</td>
+            <td>35,721.33</td>
+            <td>Data Network Lines</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,200.66</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>875.93</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>7,097.04</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>192.40</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>3,696.98</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>3,701.29</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>30,432.22</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,535.87</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>5,894.01</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>2,865.12</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>6,092.37</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,270.62</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,048.04</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Electricity</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159591</td>
+            <td>4,417.59</td>
+            <td>Electricity</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>5,436.75</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>-21.76</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>8,064.40</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>17,748.31</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>6,418.59</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>4,055.30</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>7,906.03</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>3,612.09</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>6,540.85</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>9,400.98</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>6,184.36</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Peterborough Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>3,524.37</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>RFS4 - Coventry</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.76</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>6,305.12</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>5,336.08</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Core Fee</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>2,670.47</td>
+            <td>Facilities - Core Fee</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>4,471.53</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,978.43</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>422.65</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>8,871.67</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>11,419.56</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,774.31</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>9,930.33</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>9,945.71</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>5,034.24</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>213.98</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>4,788.25</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Peterborough Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>2,050.89</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>754.56</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>4,320.54</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>12,157.95</td>
+            <td>Facilities - Quoted &amp; Ad Hoc Works</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>65.64</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>43.76</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Peterborough Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.89</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>43.76</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Maintenance</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>21.88</td>
+            <td>Furniture, Fixtures &amp; Fittings:Maintenance</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>90.59</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,350.48</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>43.50</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>200.00</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>5,476.74</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>2,550.60</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>362.16</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>545.99</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>2,006.53</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Telford Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>200.00</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>9.86</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Purchases &lt;£1,000</td>
+            <td>Weymouth Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,566.28</td>
+            <td>Furniture, Fixtures &amp; Fittings: Purchases less than £1,000.00</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>220.85</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>3,291.32</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>512.40</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,047.92</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>2,530.55</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>744.72</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>1,815.15</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FF&amp;F:Removals</td>
+            <td>Wales Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159165</td>
+            <td>276.06</td>
+            <td>Furniture, Fixtures &amp; Fittings: Removals</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Birkenhead Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>429.86</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Coventry Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>-7.21</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Croydon Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>517.42</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Director of Information Systems</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>1,370.55</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Durham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>539.50</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Fylde Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>375.19</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Gloucester Computer Centre</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>501.27</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Gloucester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>540.35</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Hull Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>421.63</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Leicester Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>471.95</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Nottingham Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>1,667.13</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+        <tr>
+            <td>Land Registry</td>
+            <td>Land Registry</td>
+            <td>19/09/2016</td>
+            <td>FM Ext Helpdesk</td>
+            <td>Peterborough Office</td>
+            <td>Carillion Services Ltd</td>
+            <td>Large</td>
+            <td>1159179</td>
+            <td>550.64</td>
+            <td>Facilities External Helpdesk</td>
+            <td>Administration</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1911,6 +1911,25 @@ pre.language-markup {
   background-color: #F5F2F0;
 }
 
+.csv-preview {
+  border: 5px solid #dee0e2;
+  margin: 30px 0 30px;
+}
+
+.csv-preview-inner {
+  border: 1px solid #bfc1c3;
+  padding: 10px 24px;
+  height: 800px;
+  overflow: auto;
+}
+
+.err {
+  background-color: #FF5353;
+  color: #fff;
+  padding: 4px;
+  font-weight: bold;
+}
+
 #back a {
   display: inline-block;
   margin-top: 15px;


### PR DESCRIPTION
A simple pre-set CSV file that is embedded directly in the HTML.  It can
be included in another page (like a /datasets/preview/csv) by using

```
{% include "includes/csv_good.html" %}
```

There is also a includes/csv_bad.html which has two highlighted cells
showing how errors might be highlighted.

Styling stolen from gov.uk
