### PR TITLE
Removes superfluous End Date section

### DIFF
--- a/app/views/manage_data/upload_new_dataset/period_year.html
+++ b/app/views/manage_data/upload_new_dataset/period_year.html
@@ -54,51 +54,7 @@ with-proposition
           </div>
         </fieldset>
 
-        <fieldset>
-          <legend>
-            <span class="form-label-bold">
-              End date
-            </span>
-          </legend>
-          <div class="form-date">
-            <div class="form-group form-group-day">
-              <label class="form-label" for="end-day">Day</label>
-              <input
-                  class="form-control"
-                  id="end-day"
-                  name="end-day"
-                  type="number"
-                  pattern="[0-9]*"
-                  min="0"
-                  max="31"
-                  value="{{ data.newSet.endDay }}"
-                  aria-describedby="end-hint">
-            </div>
-            <div class="form-group form-group-month">
-              <label class="form-label" for="end-month">Month</label>
-              <input
-                  class="form-control"
-                  id="end-month"
-                  name="end-month"
-                  type="number"
-                  pattern="[0-9]*"
-                  min="0"
-                  max="12"
-                  value="{{ data.newSet.endMonth }}">
-            </div>
-            <div class="form-group form-group-year">
-              <label class="form-label" for="end-year">Year</label>
-              <input
-                  class="form-control"
-                  id="end-year"
-                  name="end-year"
-                  type="number"
-                  pattern="[0-9]*"
-                  min="0"
-                  value="{{ data.newSet.endYear }}">
-            </div>
-          </div>
-        </fieldset>
+        <br/>
 
         <div class="form-group">
           <input type="submit" class="button" value="Continue" />


### PR DESCRIPTION
When we're asking what year a data file covers we only need the Year
field and the full End Date is unnecessary.