### PR TITLE
Remove the crown from the header

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -115,8 +115,12 @@ pre.language-markup {
 
 // Hide Crown
 
+#global-header #logo {
+  background-image: none;
+}
+
 .header-logo img {
-  display: none;
+  display: none !important;
 }
 
 .design-update {

--- a/lib/govuk_template.html
+++ b/lib/govuk_template.html
@@ -65,13 +65,13 @@
     </div>
 
     <div id="global-cookie-message">
-
+      
         {% block cookie_message %}{% endblock %}
-
+      
     </div>
     <!--end global-cookie-message-->
 
-
+    
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">
         <div class="header-global">
@@ -86,7 +86,7 @@
       </div>
     </header>
     <!--end header-->
-
+    
 
     {% block after_header %}{% endblock %}
 
@@ -106,9 +106,9 @@
 
             <div class="open-government-licence">
               <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
-
+              
                 {% block licence_message %}<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>{% endblock %}
-
+              
             </div>
           </div>
 

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1993,8 +1993,12 @@ pre.language-markup {
   color: #6f777b;
 }
 
+#global-header #logo {
+  background-image: none;
+}
+
 .header-logo img {
-  display: none;
+  display: none !important;
 }
 
 .design-update {


### PR DESCRIPTION
Stops showing the crown in the header, and stops it being used as a
background image when the img was removed.